### PR TITLE
Fix 64-bit symbol lookup arithmetic

### DIFF
--- a/src/process/process_info.rs
+++ b/src/process/process_info.rs
@@ -129,6 +129,9 @@ impl ProcessInfo {
         let library = {
             let libmap = maps.iter().find(|m| {
                 if let Some(path) = m.filename() {
+                    #[cfg(target_os = "windows")]
+                    return is_lib::<T>(path) && m.is_read();
+                    #[cfg(not(target_os = "windows"))]
                     return is_lib::<T>(path) && m.is_exec();
                 }
                 false

--- a/src/process/process_info.rs
+++ b/src/process/process_info.rs
@@ -265,7 +265,7 @@ where
     use proc_maps::win_maps::SymbolLoader;
 
     let handler = SymbolLoader::new(pid)?;
-    let _module = handler.load_module(filename)?; // need to keep this module in scope
+    let module = handler.load_module(filename)?; // need to keep this module in scope
 
     let mut ret = HashMap::new();
 
@@ -277,7 +277,7 @@ where
             // If we have a module base (ie from PDB), need to adjust by the offset
             // otherwise seems like we can take address directly
             let addr = if base == 0 {
-                addr
+                offset + addr - module.base
             } else {
                 offset + addr - base
             };


### PR DESCRIPTION
A fix for https://github.com/rbspy/rbspy/issues/340, hopefully.

The key here is that in Ruby versions from ~December 2020 or before, `offset` and `_module.base` in the `get_windows_symbols` func had the same value. But in newer versions (2.7.3+, 3.0.1+), `offset` is large while `_module.base` remains small by comparison. I could see in the memory maps produced by `proc-maps` that Ruby's main DLL was being mapped into very high virtual memory regions (0x7ffa00000000 and higher) in the newer versions -- very similar to the `offset` values. After some experimenting, I was confident that the symbol address being returned was relative to the module's base address _and also_ needed to be added to the offset. I haven't tested the `else` block that deals with a non-zero `base` value, but it might need to be updated as well.

So, what led to this? In late 2020, there was a lot of work in the upstream build tooling like MSYS2, gcc, binutils, etc that removed various hacks/workarounds and started using defaults around 64-bit image bases and ASLR. I linked to some of the relevant PRs in the linked rbspy issue. I think those changes made their way into the next Ruby release and every one after that.

One other change is needed because the first mapped memory range in the Ruby DLL is now read-only (no exec bit). My guess is that this worked by chance in earlier versions.

Test rbspy build [here](https://github.com/acj/rbspy/actions/runs/7367008827) looks good on Windows.