### PR TITLE
Adjust lib detection for nix compiled rubies

### DIFF
--- a/src/process/ruby_process_type.rs
+++ b/src/process/ruby_process_type.rs
@@ -21,7 +21,7 @@ impl ProcessType for RubyProcessType {
 
     fn library_regex() -> Regex {
         #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-        return Regex::new(r"/libruby(-\d+\.\d+)?\.so(\.\d+\.\d+(\.\d+)?)?").unwrap();
+        return Regex::new(r"/libruby(-\d+\.\d(\.\d+)?+)?\.so(\.\d+\.\d+(\.\d+)?)?").unwrap();
 
         #[cfg(target_os = "macos")]
         return Regex::new(r"/libruby\.?\d\.\d\d?\.(dylib|so)$").unwrap();


### PR DESCRIPTION
This PR *should* fix https://github.com/rbspy/rbspy/issues/374.

When building `ruby` with `nix`, the default config is to strip the binary and remove debug symbols.
However, even when overriding the build config to keep the above, `rbspy` isn't able to detect the version and VM location.

The problem is (with my tests at least) that ruby is built with a shared `libruby` and gives it a name that `rbspy` does't expect: it was looking for `libruby-3.4.so.3.4.8` in my case, but the lib was named `libruby-3.4.8.so-3.4.8` (note the 3rd digit before "so").

Modifying the lib detection regex makes `rbspy` find the version and vm, because the symbols it's looking for are in the library.

I've successfully tested with the following use cases:
`rbspy record -- /nix/store/m5zg6v819qf5fp51jfchc4ds400hnidb-ruby-3.4.8/bin/ruby -e "i = 0; while 1 do; i +=1; end"`

`rbspy record --subprocesses -- rails boot` with a rails app built using `bundlerEnv` pointing to the same ruby as above.

To build a spyable `ruby`:
```nix
  spyableruby = pkgs.enableDebugging (
    ruby_3_4.overrideAttrs (
      finalAttrs: previousAttrs: {
        dontStrip = true;
      }
    )
  );
```

EDIT: it looks like the default ruby in nixpkgs is spyable after all. No need for a special build...